### PR TITLE
Add Option<T> as an element type and positional accessors for packed matrices

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -46,3 +46,15 @@ implement!(usize);
 
 implement!(c32, c32::new(0.0, 0.0));
 implement!(c64, c64::new(0.0, 0.0));
+
+impl<T> Element for Option<T> where T: Copy + PartialEq {
+    #[inline(always)]
+    fn is_zero(&self) -> bool {
+        self.is_none()
+    }
+
+    #[inline(always)]
+    fn zero() -> Self {
+        None
+    }
+}

--- a/src/format/packed/mod.rs
+++ b/src/format/packed/mod.rs
@@ -7,6 +7,7 @@
 //! [2]: http://www.netlib.org/lapack
 
 use {Element, Matrix, Size};
+use position::Position;
 
 /// A packed matrix.
 #[derive(Clone, Debug, PartialEq)]
@@ -26,16 +27,6 @@ macro_rules! new(
     );
 );
 
-macro_rules! arithmetic(
-    ($count:expr, $first:expr, $last:expr) => (
-        $count * ($first + $last) / 2
-    );
-);
-
-macro_rules! storage(
-    ($size:expr) => (arithmetic!($size, 1, $size))
-);
-
 mod convert;
 mod operation;
 
@@ -51,18 +42,72 @@ pub enum Variant {
 #[cfg(debug_assertions)]
 impl<T: Element> ::format::Validate for Packed<T> {
     fn validate(&self) {
-        assert_eq!(self.values.len(), storage!(self.size));
+        assert_eq!(self.values.len(), triangular_elems(self.size));
     }
 }
 
 size!(Packed, size, size);
+
+/// Computes the offset into the array for the upper triangular representation
+/// Copied from http://www.netlib.org/lapack/lug/node123.html
+#[inline]
+pub fn upper_triangular_offset(n: usize, i: usize, j: usize) -> usize {
+    debug_assert!(i <= j);
+    debug_assert!(i <= n);
+    debug_assert!(j <= n);
+    // Source material uses 1-based indexing
+    let i = i + 1;
+    let j = j + 1;
+    i + j * (j - 1) / 2 - 1
+}
+
+/// Computes the offset into the array for the lower triangular representation
+/// Copied from http://www.netlib.org/lapack/lug/node123.html
+#[inline]
+pub fn lower_triangular_offset(n: usize, i: usize, j: usize) -> usize {
+    debug_assert!(j <= i);
+    debug_assert!(i <= n);
+    debug_assert!(j <= n);
+    // Source material uses 1-based indexing
+    let i = i + 1;
+    let j = j + 1;
+    i + (2 * n - j) * (j - 1) / 2 - 1
+}
+
+/// Computes how many unique elements are in a symmetric square matrix of size nxn
+#[inline]
+pub fn triangular_elems(n: usize) -> usize {
+    n * (n + 1) / 2
+}
 
 impl<T: Element> Packed<T> {
     /// Create a zero matrix.
     pub fn new<S: Size>(size: S, variant: Variant) -> Self {
         let (rows, _columns) = size.dimensions();
         debug_assert!(rows == _columns);
-        new!(rows, variant, vec![T::zero(); storage!(rows)])
+        new!(rows, variant, vec![T::zero(); triangular_elems(rows)])
+    }
+
+    /// Read an element from the matrix
+    pub fn get<P: Position>(&self, position: P) -> Option<&T> {
+        let (mut i, mut j) = position.coordinates();
+        let index = match &self.variant {
+            &Variant::Upper => {
+                if i > j {
+                    upper_triangular_offset(self.size, j, i)
+                } else {
+                    upper_triangular_offset(self.size, i, j)
+                }
+            },
+            &Variant::Lower => {
+                if j > i {
+                    lower_triangular_offset(self.size, j, i)
+                } else {
+                    lower_triangular_offset(self.size, i, j)
+                }
+            },
+        };
+        self.values.get(index)
     }
 }
 

--- a/src/format/packed/operation.rs
+++ b/src/format/packed/operation.rs
@@ -1,6 +1,6 @@
 use Element;
 use format::Packed;
-use format::packed::Variant;
+use format::packed::{Variant,triangular_elems};
 use operation::Transpose;
 
 impl<T: Element> Transpose for Packed<T> {
@@ -12,9 +12,9 @@ impl<T: Element> Transpose for Packed<T> {
         for j in 0..size {
             for i in j..size {
                 if lower {
-                    matrix.values[arithmetic!(i, 1, i) + j] = self.values[k];
+                    matrix.values[triangular_elems(i) + j] = self.values[k];
                 } else {
-                    matrix.values[k] = self.values[arithmetic!(i, 1, i) + j];
+                    matrix.values[k] = self.values[triangular_elems(i) + j];
                 }
                 k += 1;
             }


### PR DESCRIPTION
Hello, here's my first PR contribution. For this, I've added 2 small features that I've found very useful:

First, I added support for `Option<T: Element>` matrices. In my problem domain (lots of statistical computing), I have tons of cases where I have altogether missing data; for example, where I didn't have enough samples to even have a representation. Nevertheless, my problem really benefits from using the same packed memory layout, so I need to have matrices of optional values.

Second, I added a positional accessor API for the `Packed` representation, and I also included lower-level packed array indexing calculations, as I find that I constantly use these in my code.

Lastly, I cleaned up some uses of macros that expand to exactly the same implementation as inline functions, as macros don't have a good module story.

Please let me know what you think about these APIs! I have a lot more contributions I'm working on as well, and I'll begin to open issues for them as they mature.