### PR TITLE
add default impl for `is_zero` in Element

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -3,6 +3,7 @@ use {c32, c64};
 /// An element.
 pub trait Element: Copy + PartialEq {
     /// Check if the element is zero.
+    #[inline(always)]
     fn is_zero(&self) -> bool {
         self == &Self::zero()
     }
@@ -14,11 +15,6 @@ pub trait Element: Copy + PartialEq {
 macro_rules! implement(
     ($name:ty, $zero:expr) => (
         impl Element for $name {
-            #[inline(always)]
-            fn is_zero(&self) -> bool {
-                *self == $zero
-            }
-
             #[inline(always)]
             fn zero() -> Self {
                 $zero

--- a/src/element.rs
+++ b/src/element.rs
@@ -3,7 +3,9 @@ use {c32, c64};
 /// An element.
 pub trait Element: Copy + PartialEq {
     /// Check if the element is zero.
-    fn is_zero(&self) -> bool;
+    fn is_zero(&self) -> bool {
+        self == &Self::zero()
+    }
 
     /// Return the zero element.
     fn zero() -> Self;


### PR DESCRIPTION
Most likely this is what 90% of the default impls look like, so make things easier, a default implementation is provided