### PR TITLE
Enable the usage of bool as element where false is zero

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -38,6 +38,7 @@ implement!(i16);
 implement!(i32);
 implement!(i64);
 
+implement!(bool, false);
 implement!(f32, 0.0);
 implement!(f64, 0.0);
 


### PR DESCRIPTION
Sometimes you just want to have a decider matrix where each entry is either true or false. You can of course use an integer value for that, but then you get rid of the type safety (only two values vs at least 255 values).